### PR TITLE
release: milestone 2 support matrix + smoke + rollback

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-artifacts-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pf-lsp-binaries:
     name: Build pf_lsp (${{ matrix.os }})
@@ -25,10 +29,6 @@ jobs:
             artifact_name: pf_lsp-macos
             binary_path: target/release/pf_lsp
             release_asset_name: pf_lsp-macos-x64
-          - os: windows-latest
-            artifact_name: pf_lsp-windows
-            binary_path: target/release/pf_lsp.exe
-            release_asset_name: pf_lsp-windows-x64.exe
 
     steps:
       - name: Checkout
@@ -42,6 +42,20 @@ jobs:
 
       - name: Build pf_lsp
         run: cargo build --release -p pf_lsp
+
+      - name: Smoke test pf_lsp startup
+        shell: bash
+        run: |
+          set +e
+          target/release/pf_lsp </dev/null >/tmp/pf_lsp_smoke.out 2>/tmp/pf_lsp_smoke.err
+          rc=$?
+          set -e
+          if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 1 ]; then
+            echo "Unexpected pf_lsp exit code: ${rc}"
+            cat /tmp/pf_lsp_smoke.err || true
+            exit 1
+          fi
+          grep -q "Starting PF LSP Server" /tmp/pf_lsp_smoke.err
 
       - name: Prepare binary artifact
         shell: bash
@@ -69,9 +83,6 @@ jobs:
           - os: macos-latest
             vsix_target: darwin-x64
             binary_name: pf_lsp
-          - os: windows-latest
-            vsix_target: win32-x64
-            binary_name: pf_lsp.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -113,6 +124,14 @@ jobs:
           npm run compile
           npx -y @vscode/vsce package --target ${{ matrix.vsix_target }}
 
+      - name: Smoke check VSIX contents
+        shell: bash
+        run: |
+          set -euo pipefail
+          vsix_file="$(ls editors/code/*.vsix)"
+          unzip -l "${vsix_file}" | grep -q "extension/package.json"
+          unzip -l "${vsix_file}" | grep -q "extension/pf_lsp"
+
       - name: Upload VSIX
         uses: actions/upload-artifact@v6
         with:
@@ -146,6 +165,25 @@ jobs:
           cd release-bundle
           sha256sum * > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      - name: Smoke check release bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s release-bundle/pf_lsp-linux-x64
+          test -s release-bundle/pf_lsp-macos-x64
+
+          shopt -s nullglob
+          linux_vsix=(release-bundle/*-linux-x64.vsix)
+          mac_vsix=(release-bundle/*-darwin-x64.vsix)
+          if [ "${#linux_vsix[@]}" -eq 0 ] || [ "${#mac_vsix[@]}" -eq 0 ]; then
+            echo "Expected linux and macOS VSIX artifacts in release-bundle"
+            ls -la release-bundle
+            exit 1
+          fi
+
+          grep -q "pf_lsp-linux-x64" release-bundle/SHA256SUMS.txt
+          grep -q "pf_lsp-macos-x64" release-bundle/SHA256SUMS.txt
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Dependabot policy workflow to enforce expected metadata on Dependabot PRs.
 - Dogfooding roadmap model (`crates/pf_dsl/dogfooding/roadmap_q1.pf`) for planning system evolution in PF DSL.
 - Script to generate Markdown reports from dogfooding PF models (`scripts/generate_dogfooding_reports.sh`).
+- Platform support matrix document (`docs/support-matrix.md`).
+- Release rollback runbook (`docs/runbooks/release-rollback.md`).
 
 ### Changed
 - LSP now uses in-memory document state for definition and diagnostics flow.
@@ -39,6 +41,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - CodeQL now uses workflow-level concurrency cancellation for stale branch runs.
 - CI now validates all dogfooding `.pf` models to keep self-models parseable and semantically valid.
 - CI now uploads generated dogfooding Markdown reports as build artifacts.
+- Release workflow now includes artifact smoke checks (binary startup, VSIX contents, and release bundle integrity).
+- Windows release artifacts are temporarily paused; Linux/macOS remain supported targets.
 
 ### Fixed
 - VS Code extension now resolves bundled `pf_lsp` binary more robustly across platforms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,11 @@ bash ./scripts/generate_dogfooding_reports.sh
 - Push the tag; CI publishes release artifacts and creates a GitHub Release from `.github/workflows/release-artifacts.yml`.
 - VSIX artifact version is derived from the pushed tag during release workflow.
 - Release job also publishes `SHA256SUMS.txt` for integrity verification of attached files.
+- Release workflow smoke-checks supported artifacts (binary startup, VSIX contents, release bundle integrity).
 - Security audit workflow (`.github/workflows/security-audit.yml`) runs weekly and can be triggered manually.
 - CodeQL workflow (`.github/workflows/codeql.yml`) runs static analysis on pushes/PRs to `main`.
+- Supported platform matrix: `docs/support-matrix.md`.
+- Rollback procedure for broken releases: `docs/runbooks/release-rollback.md`.
 
 ## Dependabot Merge/Rebase Policy
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ See `crates/pf_dsl/sample.pf` for a complete example.
 ## Release Artifacts
 
 - CI on tag push (`v*`) or manual trigger publishes:
-  - `pf_lsp` binaries for Linux/macOS/Windows
-  - Platform-specific VSIX packages (`linux-x64`, `darwin-x64`, `win32-x64`)
+  - `pf_lsp` binaries for Linux/macOS
+  - Platform-specific VSIX packages (`linux-x64`, `darwin-x64`)
   - `SHA256SUMS.txt` with checksums for all release files
 - On tag push (`v*`), workflow also creates a GitHub Release and attaches all generated assets.
 - On tag builds, VSIX package version is automatically aligned with the git tag (e.g. `v0.1.0` -> `0.1.0`).
+- Release workflow includes smoke checks for `pf_lsp` startup, VSIX contents, and release bundle completeness.
+- Platform support policy is documented in `docs/support-matrix.md`.
+- Rollback procedure is documented in `docs/runbooks/release-rollback.md`.
 - See `.github/workflows/release-artifacts.yml`.
 
 ## Changelog

--- a/docs/runbooks/release-rollback.md
+++ b/docs/runbooks/release-rollback.md
@@ -1,0 +1,52 @@
+# Release Rollback Runbook
+
+Last updated: February 12, 2026
+
+## Scope
+
+Use this runbook when a freshly published tag release (`v*`) is broken, incomplete, or contains invalid assets.
+
+## Triggers
+
+- Release workflow failed after uploading partial assets.
+- Smoke checks detect invalid `pf_lsp` binary or VSIX package.
+- Post-release validation reports a critical regression.
+
+## Immediate Actions
+
+1. Freeze new release tags and communicate incident in the team channel.
+2. Identify affected tag and workflow run URL.
+3. Confirm impact:
+   - missing assets
+   - invalid checksum bundle
+   - runtime startup failure
+
+## Rollback Procedure
+
+1. Delete the GitHub Release for the affected tag.
+2. Delete the local and remote git tag.
+3. Revert or fix the offending commit(s) on `main`.
+4. Re-run CI and CodeQL on `main`.
+5. Create a new patch tag and publish a clean release.
+
+## Commands
+
+```bash
+# Replace vX.Y.Z with the broken tag.
+gh release delete vX.Y.Z --yes
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+```
+
+## Validation Before Re-Tag
+
+- `CI` is green on `main`.
+- `CodeQL` is green on `main`.
+- Release smoke checks pass for all supported platforms.
+- `SHA256SUMS.txt` includes all expected assets.
+
+## Post-Incident
+
+1. Add a short incident note to `CHANGELOG.md` under `[Unreleased]`.
+2. Add or tighten smoke checks that would have caught the issue earlier.
+3. Record follow-up actions in the next milestone plan.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,17 @@
+# Support Matrix
+
+Last updated: February 12, 2026
+
+## Platforms
+
+| Platform | `pf_lsp` Release Binary | VS Code VSIX | CI Coverage | Status |
+| --- | --- | --- | --- | --- |
+| Linux x64 | Yes | Yes (`linux-x64`) | Yes | Supported |
+| macOS x64 | Yes | Yes (`darwin-x64`) | Yes | Supported |
+| Windows x64 | No (temporarily disabled) | No (temporarily disabled) | Limited | Paused |
+
+## Policy Notes
+
+- Windows release artifacts are paused until dedicated Windows smoke checks and rollback coverage are in place.
+- Supported platforms must pass CI quality gates and release smoke checks.
+- Any support status change must update this file, `README.md`, and `CHANGELOG.md` in the same pull request.


### PR DESCRIPTION
Implements Milestone 2 release maturity:\n\n- add platform support matrix and pause Windows release artifacts\n- add release smoke checks (binary startup, VSIX contents, release bundle checks)\n- add release rollback runbook\n- update README/CONTRIBUTING/CHANGELOG\n