### PR TITLE
docs: windows re-enable criteria and vsix packaging metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Script to generate Markdown reports from dogfooding PF models (`scripts/generate_dogfooding_reports.sh`).
 - Platform support matrix document (`docs/support-matrix.md`).
 - Release rollback runbook (`docs/runbooks/release-rollback.md`).
+- VS Code extension packaging ignore rules (`editors/code/.vscodeignore`) and local extension license file (`editors/code/LICENSE`).
 
 ### Changed
 - LSP now uses in-memory document state for definition and diagnostics flow.
@@ -43,6 +44,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - CI now uploads generated dogfooding Markdown reports as build artifacts.
 - Release workflow now includes artifact smoke checks (binary startup, VSIX contents, and release bundle integrity).
 - Windows release artifacts are temporarily paused; Linux/macOS remain supported targets.
+- Support matrix now includes explicit Windows re-enable criteria and smoke-plan checklist.
 
 ### Fixed
 - VS Code extension now resolves bundled `pf_lsp` binary more robustly across platforms.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -15,3 +15,21 @@ Last updated: February 12, 2026
 - Windows release artifacts are paused until dedicated Windows smoke checks and rollback coverage are in place.
 - Supported platforms must pass CI quality gates and release smoke checks.
 - Any support status change must update this file, `README.md`, and `CHANGELOG.md` in the same pull request.
+
+## Windows Re-Enable Criteria
+
+Windows support may be restored only when all criteria below are met:
+
+1. A `windows-latest` release job for `pf_lsp` builds and uploads artifacts successfully for two consecutive runs.
+2. A `windows-latest` VSIX build succeeds and contains `extension/pf_lsp.exe`.
+3. A Windows smoke check validates `pf_lsp.exe` startup behavior in CI.
+4. The rollback runbook includes explicit Windows asset verification and tag rollback steps.
+5. At least one real tagged release (`v*`) ships Windows artifacts with valid checksums.
+
+## Windows Smoke Plan
+
+1. Re-introduce Windows entries in release matrices behind a temporary feature flag branch.
+2. Add smoke check for `target/release/pf_lsp.exe` analogous to Linux/macOS startup smoke test.
+3. Add VSIX smoke assertion for `extension/pf_lsp.exe`.
+4. Run manual `workflow_dispatch` release validation.
+5. After two green dry-runs, remove pause status and update this matrix to Supported.

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -1,0 +1,19 @@
+# Keep only runtime extension artifacts and trim development noise.
+src/**
+tsconfig.json
+tsconfig.tsbuildinfo
+**/*.vsix
+
+# Exclude non-runtime dependency files from packaged VSIX.
+node_modules/**/test/**
+node_modules/**/tests/**
+node_modules/**/__tests__/**
+node_modules/**/example/**
+node_modules/**/examples/**
+node_modules/**/docs/**
+node_modules/**/doc/**
+node_modules/**/.github/**
+node_modules/**/.vscode/**
+node_modules/**/*.map
+node_modules/**/README*
+node_modules/**/CHANGELOG*

--- a/editors/code/LICENSE
+++ b/editors/code/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Problem Frames DSL Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Follow-up for Milestone 2:\n\n- add explicit Windows re-enable criteria and smoke plan to support matrix\n- add editors/code/.vscodeignore to reduce VSIX packaging noise\n- add editors/code/LICENSE to satisfy VSIX license metadata checks\n- update changelog\n