### PR TITLE
Fix release smoke-check VSIX filename matching

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -180,8 +180,8 @@ jobs:
           test -s release-bundle/pf_lsp-macos-x64
 
           shopt -s nullglob
-          linux_vsix=(release-bundle/*-linux-x64.vsix)
-          mac_vsix=(release-bundle/*-darwin-x64.vsix)
+          linux_vsix=(release-bundle/*linux-x64*.vsix)
+          mac_vsix=(release-bundle/*darwin-x64*.vsix)
           if [ "${#linux_vsix[@]}" -eq 0 ] || [ "${#mac_vsix[@]}" -eq 0 ]; then
             echo "Expected linux and macOS VSIX artifacts in release-bundle"
             ls -la release-bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Support matrix now includes explicit Windows re-enable criteria and smoke-plan checklist.
 
 ### Fixed
+- Release bundle smoke-check now matches VSIX filenames that include target plus version suffix.
 - VS Code extension now resolves bundled `pf_lsp` binary more robustly across platforms.
 - Build/install scripts now copy platform-specific binary names (`pf_lsp`/`pf_lsp.exe`).
 - VS Code extension compile no longer fails on modern Node type definitions (`skipLibCheck` in `tsconfig`).


### PR DESCRIPTION
## Summary
- fix release smoke-check glob patterns for VSIX files
- support current naming format where target appears before version suffix
- add changelog note about the release smoke-check fix

## Validation
- actionlint .github/workflows/release-artifacts.yml
- pre-commit suite triggered by commit