### PR TITLE
Exclude sourcemaps from production VSIX builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed
 - VS Code extension now bundles runtime into a single `out/extension.js` via `esbuild`, and VSIX packaging excludes `node_modules`.
+- VS Code extension production build now omits source maps to reduce VSIX artifact size.
 - Critical GitHub Actions workflows now pin action refs to immutable commit SHAs.
 - CI now installs `cargo-llvm-cov` via `cargo install --locked` instead of a floating action ref.
 - LSP now uses in-memory document state for definition and diagnostics flow.

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -5,6 +5,7 @@ tsconfig.tsbuildinfo
 esbuild.js
 **/*.vsix
 node_modules/**
+out/**/*.map
 
 # Exclude non-runtime dependency files from packaged VSIX.
 node_modules/**/test/**

--- a/editors/code/esbuild.js
+++ b/editors/code/esbuild.js
@@ -1,6 +1,8 @@
 const esbuild = require("esbuild");
+const fs = require("fs");
 
 const isWatch = process.argv.includes("--watch");
+const isProduction = process.argv.includes("--production");
 
 const buildOptions = {
   entryPoints: ["src/extension.ts"],
@@ -9,12 +11,16 @@ const buildOptions = {
   format: "cjs",
   target: "node16",
   outfile: "out/extension.js",
-  sourcemap: true,
+  sourcemap: !isProduction,
   external: ["vscode"],
   logLevel: "info",
 };
 
 async function main() {
+  if (isProduction) {
+    fs.rmSync("out/extension.js.map", { force: true });
+  }
+
   if (isWatch) {
     const context = await esbuild.context(buildOptions);
     await context.watch();

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "check": "tsc --noEmit",
-    "compile": "npm run check && node ./esbuild.js",
+    "compile": "npm run check && node ./esbuild.js --production",
     "watch": "node ./esbuild.js --watch"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- make production extension bundle omit sourcemaps
- delete stale out/extension.js.map in production build path
- explicitly ignore out/**/*.map in VSIX packaging
- update changelog entry for reduced VSIX size

## Validation
- cd editors/code && npm run compile
- cd editors/code && npx -y @vscode/vsce package --target linux-x64 (VSIX no longer contains extension.js.map)
- pre-commit suite triggered by commit