### PR TITLE
release: checkout repo in publish job for syft config

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -153,6 +153,9 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Download all artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:


### PR DESCRIPTION
## What
- add `actions/checkout` to `publish-release` job in release workflow

## Why
`anchore/sbom-action` is configured with `config: .github/syft-release.yaml`. In `publish-release`, repo files were unavailable (no checkout), causing SBOM generation to fail for tag `v0.1.2`.

## Validation
- workflow YAML parses locally
- pre-commit checks passed
