### PR TITLE
ci: guard release workflow SBOM checks on PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - GitHub Release now includes `SHA256SUMS.txt` with checksums for all published assets.
 - GitHub workflows now use `actions/checkout@v6` and `actions/setup-node@v6`.
 - Release workflow now uses `actions/upload-artifact@v6` and `actions/download-artifact@v7`.
+- CI script smoke checks now verify release workflow SBOM guardrails (`publish-release` checkout, Syft config wiring, and checksum validation step).
 - Dependabot now uses explicit auto-rebase policy and grouped editor dependency updates.
 - CodeQL now runs language-specific jobs only when matching source areas changed on push/PR.
 - CI now enforces a Rust line-coverage gate via `cargo llvm-cov` (`--fail-under-lines 54`).

--- a/scripts/smoke_test_scripts.sh
+++ b/scripts/smoke_test_scripts.sh
@@ -7,5 +7,6 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 echo "Smoke testing release/install scripts in dry-run mode..."
 PF_DRY_RUN=1 "${REPO_ROOT}/scripts/build_vsix.sh"
 PF_DRY_RUN=1 "${REPO_ROOT}/scripts/install_extension.sh"
+bash "${REPO_ROOT}/scripts/verify_release_workflow_guardrails.sh"
 
 echo "Script smoke tests passed."

--- a/scripts/verify_release_workflow_guardrails.sh
+++ b/scripts/verify_release_workflow_guardrails.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+WORKFLOW_PATH="${REPO_ROOT}/.github/workflows/release-artifacts.yml"
+SYFT_CONFIG_PATH="${REPO_ROOT}/.github/syft-release.yaml"
+
+if [[ ! -f "${WORKFLOW_PATH}" ]]; then
+  echo "Missing workflow file: ${WORKFLOW_PATH}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${SYFT_CONFIG_PATH}" ]]; then
+  echo "Missing Syft config file: ${SYFT_CONFIG_PATH}" >&2
+  exit 1
+fi
+
+# Parse YAML with stdlib parser to fail fast on syntax errors.
+ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); YAML.load_file(ARGV[1])' \
+  "${WORKFLOW_PATH}" \
+  "${SYFT_CONFIG_PATH}"
+
+publish_release_block="$(
+  awk '
+    /^  publish-release:/ { in_block=1 }
+    in_block && /^  [A-Za-z0-9_-]+:/ && $0 !~ /^  publish-release:/ { in_block=0 }
+    in_block { print }
+  ' "${WORKFLOW_PATH}"
+)"
+
+if [[ -z "${publish_release_block}" ]]; then
+  echo "publish-release job block not found in ${WORKFLOW_PATH}" >&2
+  exit 1
+fi
+
+require_in_publish_release() {
+  local pattern="$1"
+  local description="$2"
+  if ! grep -qE "${pattern}" <<<"${publish_release_block}"; then
+    echo "Missing release guardrail in publish-release: ${description}" >&2
+    exit 1
+  fi
+}
+
+require_in_publish_release 'name: Checkout' 'repository checkout step'
+require_in_publish_release 'name: Generate release SBOM' 'SBOM generation step'
+require_in_publish_release 'config: \.github/syft-release\.yaml' 'Syft config wiring'
+require_in_publish_release 'syft-version: v1\.38\.0' 'pinned Syft version'
+require_in_publish_release 'name: Validate SBOM checksums for release binaries' 'SBOM checksum validation step'
+
+if ! grep -qE 'selection:[[:space:]]*all' "${SYFT_CONFIG_PATH}"; then
+  echo "Syft config must keep file.metadata.selection=all for release fidelity" >&2
+  exit 1
+fi
+
+if ! grep -qE -- '-[[:space:]]*sha256' "${SYFT_CONFIG_PATH}"; then
+  echo "Syft config must include sha256 digest collection" >&2
+  exit 1
+fi
+
+echo "Release workflow guardrails are configured."


### PR DESCRIPTION
## What
- add `scripts/verify_release_workflow_guardrails.sh`
- run this guardrail script in `scripts/smoke_test_scripts.sh`
- note the change in changelog

## Why
Release-only regressions (like missing checkout/config wiring in `publish-release`) should fail on PRs, not only after creating a release tag.

## Validation
- `bash ./scripts/verify_release_workflow_guardrails.sh`
- `bash ./scripts/smoke_test_scripts.sh`
- pre-commit checks passed
