### PR TITLE
docs: define v0.2.0 scope and exit criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Script to generate Markdown reports from dogfooding PF models (`scripts/generate_dogfooding_reports.sh`).
 - Platform support matrix document (`docs/support-matrix.md`).
 - Release rollback runbook (`docs/runbooks/release-rollback.md`).
+- `v0.2.0` scope proposal with explicit exit criteria (`docs/proposals/005-v0.2.0-scope-and-exit-criteria.md`).
 - VS Code extension packaging ignore rules (`editors/code/.vscodeignore`) and local extension license file (`editors/code/LICENSE`).
 
 ### Changed

--- a/docs/proposals/005-v0.2.0-scope-and-exit-criteria.md
+++ b/docs/proposals/005-v0.2.0-scope-and-exit-criteria.md
@@ -1,0 +1,84 @@
+# Proposal 005: v0.2.0 Scope and Exit Criteria
+
+## Status
+
+Draft
+
+## Planning Window
+
+- Start: February 13, 2026
+- Target release cut: April 30, 2026
+
+## Objective
+
+Define a focused `v0.2.0` scope that improves product reliability and planning maturity without overloading the release.
+
+## Scope Summary
+
+`v0.2.0` includes three product goals and one formal-methods spike.
+
+### Product Goal 1: Release Reliability as a Merge-Time Contract
+
+- Keep release workflow guardrails checked on pull requests, not only on tag builds.
+- Enforce stable release bundle quality (`SHA256SUMS`, SBOM quality checks, provenance bundles).
+- Keep platform policy explicit (Linux/macOS supported, Windows status documented and gated).
+
+Exit criteria:
+
+- Two consecutive release tags complete successfully with full security metadata.
+- No release incident caused by missing workflow wiring/config.
+
+### Product Goal 2: Dogfooding-Driven Planning Loop
+
+- Use PF dogfooding models as planning artifacts, not just examples.
+- Generate a weekly Markdown report that maps model findings to prioritized actions.
+- Track owner + due date for top actions in the weekly triage issue.
+
+Exit criteria:
+
+- Two weekly triage cycles use generated dogfooding outputs as primary input.
+- Each cycle closes or re-plans at least one top-priority dogfooding action.
+
+### Product Goal 3: Validator and LSP Quality Tightening
+
+- Improve confidence in diagnostics stability for unsaved-buffer and definition flows.
+- Extend integration fixtures for high-value failure modes (missing refs, frame misuse, command origin issues).
+- Keep CI signal quality high (low flaky rate, clear failing checks).
+
+Exit criteria:
+
+- Add at least three new integration/semantic fixtures that catch prior blind spots.
+- Keep `main` red rate below 5% during the milestone window.
+
+### Formal Spike: Lean/K Feasibility Check (Research Track)
+
+- Keep Rust validator as production path.
+- Deliver one end-to-end formal artifact for a real PF model:
+  - generated Lean model from PF AST
+  - one non-trivial proved property
+  - differential result compared with Rust validator
+- K Framework remains optional and limited to one scoped experiment if capacity allows.
+
+Exit criteria:
+
+- One documented proof case runs in CI (non-blocking).
+- One short decision memo recommends next step: continue Lean-first, pause, or expand to K experiment.
+
+## Out of Scope for v0.2.0
+
+- Replacing Rust validator with theorem proving on the LSP path.
+- Broad DSL redesign or syntax overhaul.
+- Full enterprise governance/compliance feature set.
+
+## Risks and Mitigations
+
+- Risk: Scope creep across product + formal tracks.
+  - Mitigation: Enforce exit criteria as the only release gate for this milestone.
+- Risk: CI latency increase.
+  - Mitigation: Keep formal checks non-blocking and path-scoped.
+- Risk: Planning artifacts become stale.
+  - Mitigation: Tie dogfooding output directly to weekly triage issue template.
+
+## Decision Needed
+
+Approve this scope as the default plan for `v0.2.0`.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -8,6 +8,7 @@ This directory contains product and engineering proposals for Problem Frames.
 - `002-formal-verification-track.md`: Parallel formal methods track (Lean first, K optional) without blocking the main Rust workflow.
 - `003-adoption-and-gtm.md`: ICP, adoption path, and proof-of-value plan for real teams.
 - `004-lean-integration-proposal.md`: Lean 4 integration details (semantics, transpilation, and phased rollout).
+- `005-v0.2.0-scope-and-exit-criteria.md`: scoped `v0.2.0` plan with product goals, formal spike, and concrete exit criteria.
 
 ## Proposal Status
 


### PR DESCRIPTION
## What
- add `docs/proposals/005-v0.2.0-scope-and-exit-criteria.md`
- link proposal in `docs/proposals/README.md`
- mention proposal in changelog

## Why
We need a concrete post-0.1.x plan with explicit scope and exit criteria so work can be prioritized and measured, including formal-methods track boundaries.

## Validation
- pre-commit checks passed
- proposal aligns with existing roadmap + formal-track drafts
