### PR TITLE
ops: feed dogfooding priorities into weekly triage

### DIFF
--- a/.github/workflows/weekly-engineering-triage.yml
+++ b/.github/workflows/weekly-engineering-triage.yml
@@ -27,6 +27,9 @@ jobs:
           METRICS_WINDOW_DAYS: "7"
         run: bash ./scripts/generate_engineering_metrics_report.sh .ci-artifacts/metrics
 
+      - name: Generate dogfooding triage backlog
+        run: bash ./scripts/generate_dogfooding_triage_report.sh .ci-artifacts/metrics
+
       - name: Upload metrics report artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
@@ -82,6 +85,12 @@ jobs:
               metrics = fs.readFileSync(reportPath, "utf8");
             }
 
+            let dogfooding = "_Dogfooding triage report artifact is missing._";
+            const dogfoodingPath = "metrics-report/dogfooding-triage.md";
+            if (fs.existsSync(dogfoodingPath)) {
+              dogfooding = fs.readFileSync(dogfoodingPath, "utf8");
+            }
+
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const body = [
               `Weekly triage for engineering health baseline (${weekStart}).`,
@@ -90,13 +99,17 @@ jobs:
               "- [ ] Review dependency backlog (Dependabot PRs + blocked updates).",
               "- [ ] Review CI regressions and flaky-test candidates.",
               "- [ ] Review security signals (CodeQL, dependency review, audits).",
+              "- [ ] Review dogfooding backlog and assign owner/due date for top actions.",
               "- [ ] Confirm recovery actions for incidents and failed changes.",
               "- [ ] Assign owners and due dates for follow-up actions.",
               "",
               `Workflow run: ${runUrl}`,
               "",
               "## Metrics Snapshot",
-              metrics
+              metrics,
+              "",
+              "## Dogfooding Priorities",
+              dogfooding
             ].join("\n");
 
             await github.rest.issues.create({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Dependabot policy workflow to enforce expected metadata on Dependabot PRs.
 - Dogfooding roadmap model (`crates/pf_dsl/dogfooding/roadmap_q1.pf`) for planning system evolution in PF DSL.
 - Script to generate Markdown reports from dogfooding PF models (`scripts/generate_dogfooding_reports.sh`).
+- Dogfooding triage backlog generator (`scripts/generate_dogfooding_triage_report.sh`) for weekly owner/due-date planning.
 - Platform support matrix document (`docs/support-matrix.md`).
 - Release rollback runbook (`docs/runbooks/release-rollback.md`).
 - `v0.2.0` scope proposal with explicit exit criteria (`docs/proposals/005-v0.2.0-scope-and-exit-criteria.md`).
@@ -48,6 +49,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - GitHub workflows now use `actions/checkout@v6` and `actions/setup-node@v6`.
 - Release workflow now uses `actions/upload-artifact@v6` and `actions/download-artifact@v7`.
 - CI script smoke checks now verify release workflow SBOM guardrails (`publish-release` checkout, Syft config wiring, and checksum validation step).
+- Weekly engineering triage now includes dogfooding priority backlog in the generated issue body.
 - Dependabot now uses explicit auto-rebase policy and grouped editor dependency updates.
 - CodeQL now runs language-specific jobs only when matching source areas changed on push/PR.
 - CI now enforces a Rust line-coverage gate via `cargo llvm-cov` (`--fail-under-lines 54`).

--- a/docs/runbooks/weekly-triage.md
+++ b/docs/runbooks/weekly-triage.md
@@ -7,7 +7,7 @@ This runbook establishes a weekly triage cadence for engineering health signals.
 - Frequency: weekly (Monday, 09:00 UTC)
 - Trigger: `.github/workflows/weekly-engineering-triage.yml`
 - Output:
-  - artifact `engineering-metrics` (`engineering-metrics.md`, `engineering-metrics.json`)
+  - artifact `engineering-metrics` (`engineering-metrics.md`, `engineering-metrics.json`, `dogfooding-triage.md`)
   - scheduled issue `Weekly engineering triage YYYY-MM-DD`
 
 ## Inputs
@@ -19,6 +19,7 @@ This runbook establishes a weekly triage cadence for engineering health signals.
    - CodeQL
    - dependency-review
    - security audit
+5. Dogfooding triage backlog (`dogfooding-triage.md`).
 
 ## Triage Agenda
 
@@ -34,6 +35,7 @@ This runbook establishes a weekly triage cadence for engineering health signals.
    - owner
    - due date
    - success signal
+6. Confirm the top dogfooding actions are either accepted (owner/date assigned) or explicitly deferred.
 
 ## Exit Criteria (for each weekly session)
 

--- a/scripts/generate_dogfooding_triage_report.sh
+++ b/scripts/generate_dogfooding_triage_report.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+INPUT_DIR="${DOGFOODING_INPUT_DIR:-${REPO_ROOT}/crates/pf_dsl/dogfooding}"
+OUTPUT_DIR="${1:-${REPO_ROOT}/docs/dogfooding-reports}"
+OUTPUT_FILE="${OUTPUT_DIR}/dogfooding-triage.md"
+
+if [[ ! -d "${INPUT_DIR}" ]]; then
+  echo "Dogfooding directory not found: ${INPUT_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+raw_rows="$(mktemp)"
+sorted_rows="$(mktemp)"
+trap 'rm -f "${raw_rows}" "${sorted_rows}"' EXIT
+
+trim_line() {
+  local input="$1"
+  sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<<"${input}"
+}
+
+escape_md() {
+  local input="$1"
+  input="${input//|/\\|}"
+  printf '%s' "${input}"
+}
+
+emit_row() {
+  local model="$1"
+  local req="$2"
+  local frame="$3"
+  local constrains="$4"
+  local reference="$5"
+  local constraint="$6"
+  local priority="P3"
+  local action="Review semantics coverage and add a targeted fixture."
+
+  if [[ "${frame}" == "CommandedBehavior" ]]; then
+    priority="P1"
+    action="Add/refresh command-origin fixture for \`${reference}\` -> \`${constrains}\`."
+  elif [[ "${frame}" == "RequiredBehavior" ]]; then
+    priority="P2"
+    action="Add/refresh required-behavior fixture anchored on \`${constrains}\`."
+  elif [[ "${frame}" == "InformationDisplay" ]]; then
+    priority="P2"
+    action="Add regression fixture for information projection rules."
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${priority}" \
+    "$(escape_md "${model}")" \
+    "$(escape_md "${req}")" \
+    "$(escape_md "${frame}")" \
+    "$(escape_md "${action}")" \
+    "$(escape_md "${constraint}")" >> "${raw_rows}"
+}
+
+while IFS= read -r model_path; do
+  model_rel="${model_path#${INPUT_DIR}/}"
+  in_req=0
+  req=""
+  frame=""
+  constrains=""
+  reference=""
+  constraint=""
+
+  while IFS= read -r raw_line || [[ -n "${raw_line}" ]]; do
+    line="${raw_line%%//*}"
+    line="$(trim_line "${line}")"
+    if [[ -z "${line}" ]]; then
+      continue
+    fi
+
+    if [[ "${in_req}" -eq 0 ]]; then
+      if [[ "${line}" =~ ^requirement[[:space:]]+\"([^\"]+)\" ]]; then
+        in_req=1
+        req="${BASH_REMATCH[1]}"
+        frame="Unknown"
+        constrains=""
+        reference=""
+        constraint=""
+      fi
+      continue
+    fi
+
+    if [[ "${line}" =~ ^frame:[[:space:]]*([A-Za-z0-9_]+) ]]; then
+      frame="${BASH_REMATCH[1]}"
+      continue
+    fi
+    if [[ "${line}" =~ ^constrains:[[:space:]]*([A-Za-z0-9_]+) ]]; then
+      constrains="${BASH_REMATCH[1]}"
+      continue
+    fi
+    if [[ "${line}" =~ ^reference:[[:space:]]*([A-Za-z0-9_]+) ]]; then
+      reference="${BASH_REMATCH[1]}"
+      continue
+    fi
+    if [[ "${line}" =~ ^constraint:[[:space:]]*\"(.*)\"$ ]]; then
+      constraint="${BASH_REMATCH[1]}"
+      continue
+    fi
+    if [[ "${line}" =~ ^\} ]]; then
+      emit_row "${model_rel}" "${req}" "${frame}" "${constrains}" "${reference}" "${constraint}"
+      in_req=0
+    fi
+  done < "${model_path}"
+done < <(
+  find "${INPUT_DIR}" \
+    -type f \
+    -name "*.pf" \
+    ! -path "*/import_test/*" \
+    ! -path "*/std_test/*" \
+    | sort
+)
+
+sort -t$'\t' -k1,1 -k2,2 -k3,3 "${raw_rows}" > "${sorted_rows}"
+
+generated_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+total_actions="$(wc -l < "${sorted_rows}" | tr -d ' ')"
+p1_count="$(awk -F'\t' '$1=="P1"{c++} END{print c+0}' "${sorted_rows}")"
+p2_count="$(awk -F'\t' '$1=="P2"{c++} END{print c+0}' "${sorted_rows}")"
+p3_count="$(awk -F'\t' '$1=="P3"{c++} END{print c+0}' "${sorted_rows}")"
+
+{
+  echo "# Dogfooding Triage Backlog"
+  echo
+  echo "- Generated (UTC): \`${generated_at}\`"
+  echo "- Source: \`${INPUT_DIR}\`"
+  echo
+  echo "## Priority Summary"
+  echo
+  echo "| Bucket | Count |"
+  echo "| --- | ---: |"
+  echo "| P1 | ${p1_count} |"
+  echo "| P2 | ${p2_count} |"
+  echo "| P3 | ${p3_count} |"
+  echo "| Total | ${total_actions} |"
+  echo
+  echo "## Top Actions"
+  echo
+  echo "| Priority | Model | Requirement | Frame | Proposed Action | Constraint Context | Owner | Due Date | Status |"
+  echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+
+  if [[ "${total_actions}" -eq 0 ]]; then
+    echo "| n/a | n/a | n/a | n/a | No requirements found in dogfooding models. | n/a | n/a | n/a | n/a |"
+  else
+    row_count=0
+    while IFS=$'\t' read -r priority model requirement frame_name action_text constraint_text; do
+      row_count=$((row_count + 1))
+      if [[ "${row_count}" -gt 12 ]]; then
+        break
+      fi
+      printf '| %s | `%s` | `%s` | `%s` | %s | %s | TBD | TBD | Open |\n' \
+        "${priority}" \
+        "${model}" \
+        "${requirement}" \
+        "${frame_name}" \
+        "${action_text}" \
+        "${constraint_text}"
+    done < "${sorted_rows}"
+  fi
+
+  echo
+  echo "## Usage"
+  echo
+  echo "- Review this table in weekly triage."
+  echo "- Replace \`TBD\` with concrete owner and due date for accepted actions."
+  echo "- Replan or close stale actions in the next cycle."
+} > "${OUTPUT_FILE}"
+
+echo "Generated ${OUTPUT_FILE}"

--- a/scripts/smoke_test_scripts.sh
+++ b/scripts/smoke_test_scripts.sh
@@ -9,4 +9,8 @@ PF_DRY_RUN=1 "${REPO_ROOT}/scripts/build_vsix.sh"
 PF_DRY_RUN=1 "${REPO_ROOT}/scripts/install_extension.sh"
 bash "${REPO_ROOT}/scripts/verify_release_workflow_guardrails.sh"
 
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+bash "${REPO_ROOT}/scripts/generate_dogfooding_triage_report.sh" "${tmp_dir}"
+
 echo "Script smoke tests passed."


### PR DESCRIPTION
## What
- add `scripts/generate_dogfooding_triage_report.sh`
- generate `dogfooding-triage.md` in weekly engineering triage workflow artifact
- include dogfooding priorities in scheduled triage issue body
- smoke-test the new script via `scripts/smoke_test_scripts.sh`
- update runbook/changelog

## Why
Dogfooding models should produce concrete weekly planning actions (with owner + due date), not only static reports.

## Validation
- `bash ./scripts/generate_dogfooding_triage_report.sh <tmp_dir>`
- `bash ./scripts/smoke_test_scripts.sh`
- workflow YAML parsed with Ruby YAML parser
- pre-commit checks passed
