### PR TITLE
ops: auto-assign dogfooding triage owners and due dates

### DIFF
--- a/.github/dogfooding-triage-owners.tsv
+++ b/.github/dogfooding-triage-owners.tsv
@@ -1,0 +1,5 @@
+# model_regex	requirement_regex	owner	due_days	status
+^roadmap_q1\.pf$	^RoadmapPrioritization$	@kirill-0440	7	Planned
+^roadmap_q1\.pf$	.*	@kirill-0440	14	Planned
+^tool_spec\.pf$	.*	@kirill-0440	10	Planned
+.*	.*	@kirill-0440	21	Planned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Dogfooding roadmap model (`crates/pf_dsl/dogfooding/roadmap_q1.pf`) for planning system evolution in PF DSL.
 - Script to generate Markdown reports from dogfooding PF models (`scripts/generate_dogfooding_reports.sh`).
 - Dogfooding triage backlog generator (`scripts/generate_dogfooding_triage_report.sh`) for weekly owner/due-date planning.
+- Dogfooding owner-routing rules (`.github/dogfooding-triage-owners.tsv`) for auto-assigned triage owner and due date.
 - Platform support matrix document (`docs/support-matrix.md`).
 - Release rollback runbook (`docs/runbooks/release-rollback.md`).
 - `v0.2.0` scope proposal with explicit exit criteria (`docs/proposals/005-v0.2.0-scope-and-exit-criteria.md`).
@@ -50,6 +51,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Release workflow now uses `actions/upload-artifact@v6` and `actions/download-artifact@v7`.
 - CI script smoke checks now verify release workflow SBOM guardrails (`publish-release` checkout, Syft config wiring, and checksum validation step).
 - Weekly engineering triage now includes dogfooding priority backlog in the generated issue body.
+- Dogfooding triage report now auto-fills owner/due date/status from mapping rules instead of leaving `TBD`.
 - Dependabot now uses explicit auto-rebase policy and grouped editor dependency updates.
 - CodeQL now runs language-specific jobs only when matching source areas changed on push/PR.
 - CI now enforces a Rust line-coverage gate via `cargo llvm-cov` (`--fail-under-lines 54`).

--- a/docs/runbooks/weekly-triage.md
+++ b/docs/runbooks/weekly-triage.md
@@ -20,6 +20,7 @@ This runbook establishes a weekly triage cadence for engineering health signals.
    - dependency-review
    - security audit
 5. Dogfooding triage backlog (`dogfooding-triage.md`).
+   - owner/SLA rules are configured in `.github/dogfooding-triage-owners.tsv`
 
 ## Triage Agenda
 


### PR DESCRIPTION
## What
- add owner routing file: `.github/dogfooding-triage-owners.tsv`
- update `scripts/generate_dogfooding_triage_report.sh` to auto-assign owner, due date, and status from mapping rules
- document mapping usage in weekly triage runbook
- update changelog

## Why
Weekly triage should produce directly actionable backlog items without manual `TBD` placeholders.

## Validation
- `bash ./scripts/generate_dogfooding_triage_report.sh <tmp_dir>`
- `bash ./scripts/smoke_test_scripts.sh`
- pre-commit checks passed
