### PR TITLE
ci: reset llvm-cov profile workspace before coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
 
+      - name: Reset coverage profile workspace
+        run: rm -rf target/llvm-cov-target
+
       - name: Coverage gate
         run: |
           cargo llvm-cov \

--- a/models/system/requirements.pf
+++ b/models/system/requirements.pf
@@ -156,7 +156,7 @@ requirement "R004-L4-LeanDifferentialContract" {
 // Proposal 005: v0.2.0 scope and exit criteria.
 requirement "R005-G1-ReleaseReliabilityContract" {
     frame: RequiredBehavior
-    constraint: "CI quality gates execute reliably for merge-time contract enforcement"
+    constraint: "CI quality gates execute reliably for merge-time contract enforcement, including cache-hygienic coverage runs that reset transient llvm-cov profile artifacts before threshold checks"
     marks: {
         @formal.argument("A_roadmap_alignment")
         @mda.layer("CIM")


### PR DESCRIPTION
## Summary
- update self-model requirement `R005-G1-ReleaseReliabilityContract` to explicitly require cache-hygienic coverage gating
- harden the Rust coverage gate by resetting `target/llvm-cov-target` before `cargo llvm-cov`

## Why
The latest `main` CI run failed at `Coverage gate` because a corrupt `*.profraw` was present under `target/llvm-cov-target`.

## Validation
- `bash ./scripts/check_codex_self_model_contract.sh`
- `rm -rf target/llvm-cov-target && cargo llvm-cov --workspace --all-features --fail-under-lines 54 --summary-only`
- pre-commit checks triggered by `git commit`
